### PR TITLE
Ändert TSV Format für Modbus Adapter 6.x

### DIFF
--- a/SUNNY_TRIPOWER _10.0_SE/modbus_register/eingang.tsv
+++ b/SUNNY_TRIPOWER _10.0_SE/modbus_register/eingang.tsv
@@ -1,35 +1,35 @@
-_address	deviceId	name	description	unit	type	len	factor	offset	formula	role	room	cw	isScale
-30053	3	DevTypeId			uint32be	2	1	0		value		false	false
-30193	3	Systemzeit als trigger			uint32be	2	1	0		value.time		false	false
-30203	3	WR Wirkleistung Max		W	uint32be	2	1	0		value		false	false
-30517	3	Tag Verbrauch gesamt		kWh	uint64be	4	0.001	0		value		false	false
-30529	3	AC-Gesamtertrag		kWh	uint32be	2	0.001	0		value		false	false
-30531	3	AC-Gesamtertrag		kWh	uint32be	2	1	0		value		false	false
-30533	3	AC-Gesamtertrag		MWh	uint32be	2	1	0		value		false	false
-30581	3	Gekaufte Energie		kWh	uint32be	2	0.001	0		value		false	false
-30583	3	Zählerstand Einspeisezähler		kWh	uint32be	2	0.001	0		value		false	false
-30769	3	DC-Strom 1		A	int32be	2	0.001	0		value		false	false
-30771	3	DC-Spannung 1		V	int32be	2	0.01	0		value		false	false
-30773	3	DC-Leistung 1		W	int32be	2	1	0	x=(x<0) ? 0:x	value		false	false
-30775	3	AC-Leistung		W	int32be	2	1	0		value		false	false
-30837	3	Wirkleistungsbegrenzung W		W	uint32be	2	1	0		value		false	false
-30839	3	Wirkleistungsbegrenzung %		%	uint32be	2	1	0		value		false	false
-30845	3	Batterie Prozent		%	uint32be	2	1	0		value		false	false
-30847	3	Diagnose Aktuelle Kapazität		%	uint32be	2	1	0		value		false	false
-30849	3	Batterie Temperatur		°C	int32be	2	0,1	0		value		false	false
-30865	3	Aktueller Netzbezug		W	uint32be	2	1			value		false	false
-30867	3	Aktuelle Netzeinspeisung		W	int32be	2	1	0		value		false	false
-30953	3	Temperatur WR		°C	int32be	2	0.1	0		value		false	false
-30955	3	Batterie Zustand			uint32be	2	1	0		value		false	false
-30957	3	DC-Strom 2		A	int32be	2	0.001	0		value		false	false
-30959	3	DC-Spannung 2		V	int32be	2	0.01	0		value		false	false
-30961	3	DC-Leistung 2		W	int32be	2	1	0	x=(x<0) ? 0:x	value		false	false
-31061	3	Steuerung verfügbar			uint32be	2	1	0		value		false	false
-31379	3	Batterietyp			uint32be	2	1	0		value		false	false
-31391	3	Batterie Status			uint32be	2	1	0		value		false	false
-31393	3	Momentane Batterieladung		W	uint32be	2	1	0		value		false	false
-31395	3	Momentane Batterieentladung		W	uint32be	2	1	0		value		false	false
-31397	3	Batterieladung		Wh	uint64be	4	1	0		value		false	false
-31401	3	Batterieentladung		Wh	uint64be	4	1	0		value		false	false
-32385	3	WR Status			uint32be	2	1	0		value		false	false
-32405	3	Verbleibende Laufzeit bis WR Neustart			uint32be	2	1	0		value		false	false
+_address	name	description	unit	type	len	factor	offset	formula	role	room	cw	isScale
+30053	DevTypeId			uint32be	2	1	0		value		false	false
+30193	Systemzeit als trigger			uint32be	2	1	0		value.time		false	false
+30203	WR Wirkleistung Max		W	uint32be	2	1	0		value		false	false
+30517	Tag Verbrauch gesamt		kWh	uint64be	4	0.001	0		value		false	false
+30529	AC-Gesamtertrag		kWh	uint32be	2	0.001	0		value		false	false
+30531	AC-Gesamtertrag		kWh	uint32be	2	1	0		value		false	false
+30533	AC-Gesamtertrag		MWh	uint32be	2	1	0		value		false	false
+30581	Gekaufte Energie		kWh	uint32be	2	0.001	0		value		false	false
+30583	Zählerstand Einspeisezähler		kWh	uint32be	2	0.001	0		value		false	false
+30769	DC-Strom 1		A	int32be	2	0.001	0		value		false	false
+30771	DC-Spannung 1		V	int32be	2	0.01	0		value		false	false
+30773	DC-Leistung 1		W	int32be	2	1	0	x=(x<0) ? 0:x	value		false	false
+30775	AC-Leistung		W	int32be	2	1	0		value		false	false
+30837	Wirkleistungsbegrenzung W		W	uint32be	2	1	0		value		false	false
+30839	Wirkleistungsbegrenzung %		%	uint32be	2	1	0		value		false	false
+30845	Batterie Prozent		%	uint32be	2	1	0		value		false	false
+30847	Diagnose Aktuelle Kapazität		%	uint32be	2	1	0		value		false	false
+30849	Batterie Temperatur		°C	int32be	2	0,1	0		value		false	false
+30865	Aktueller Netzbezug		W	uint32be	2	1			value		false	false
+30867	Aktuelle Netzeinspeisung		W	int32be	2	1	0		value		false	false
+30953	Temperatur WR		°C	int32be	2	0.1	0		value		false	false
+30955	Batterie Zustand			uint32be	2	1	0		value		false	false
+30957	DC-Strom 2		A	int32be	2	0.001	0		value		false	false
+30959	DC-Spannung 2		V	int32be	2	0.01	0		value		false	false
+30961	DC-Leistung 2		W	int32be	2	1	0	x=(x<0) ? 0:x	value		false	false
+31061	Steuerung verfügbar			uint32be	2	1	0		value		false	false
+31379	Batterietyp			uint32be	2	1	0		value		false	false
+31391	Batterie Status			uint32be	2	1	0		value		false	false
+31393	Momentane Batterieladung		W	uint32be	2	1	0		value		false	false
+31395	Momentane Batterieentladung		W	uint32be	2	1	0		value		false	false
+31397	Batterieladung		Wh	uint64be	4	1	0		value		false	false
+31401	Batterieentladung		Wh	uint64be	4	1	0		value		false	false
+32385	WR Status			uint32be	2	1	0		value		false	false
+32405	Verbleibende Laufzeit bis WR Neustart			uint32be	2	1	0		value		false	false

--- a/SUNNY_TRIPOWER _10.0_SE/modbus_register/holding.tsv
+++ b/SUNNY_TRIPOWER _10.0_SE/modbus_register/holding.tsv
@@ -1,7 +1,7 @@
-_address	deviceId	name	description	unit	type	len	factor	offset	formula	role	room	poll	wp	cw	isScale
-40149	3	Wirkleistungvorgabe		W	int32be	2	1	0		level		false	false	false	false
-40151	3	Kommunikation			uint32be	2	1	0		state		false	false	false	false
-40189	3	max Ladeleistung BatWR		W	uint32be	2	1	0		level		true	false	false	
-40191	3	max Entladeleistung BatWR		W	uint32be	2	1	0		level		true	false	false	
-40795	3	Maximale Batterieladeleistung		W	uint32be	2	1	0		level		false	false	false	
-40799	3	Maximale Batterieentladeleistung		W	uint32be	2	1	0		level		false	false	false	
+_address	name	description	unit	type	len	factor	offset	formula	role	room	poll	wp	cw	isScale
+40149	Wirkleistungvorgabe		W	int32be	2	1	0		level		false	false	false	false
+40151	Kommunikation			uint32be	2	1	0		state		false	false	false	false
+40189	max Ladeleistung BatWR		W	uint32be	2	1	0		level		true	false	false	
+40191	max Entladeleistung BatWR		W	uint32be	2	1	0		level		true	false	false	
+40795	Maximale Batterieladeleistung		W	uint32be	2	1	0		level		false	false	false	
+40799	Maximale Batterieentladeleistung		W	uint32be	2	1	0		level		false	false	false	


### PR DESCRIPTION
Im TSV Import/Export Format des Iobroker Modbus Adapters 6.2.3 ist die device_id nicht mehr enthalten.